### PR TITLE
Remove SysInspector and MBST logs.

### DIFF
--- a/src/config/tools.xml
+++ b/src/config/tools.xml
@@ -342,6 +342,12 @@
         <process companyName="(?i)^ESET" force="0" process="(?i)^esetlogcollector.*\.exe$"/>
         <registryKey force="0" key="HKCU\Software\ESET\ESET Log Collector"/>
     </tool>
+    <tool name="ESET SysInspector">
+        <desktop companyName="(?i)^ESET" pattern="(?i)^sysinspector.*\.exe$" type="file"/>
+        <desktop companyName="" pattern="(?i)^esi-eula\.rtf$" type="file"/>
+        <download companyName="(?i)^ESET" pattern="(?i)^sysinspector.*\.exe$" type="file"/>
+        <download companyName="" pattern="(?i)^esi-eula\.rtf$" type="file"/>
+    </tool>
     <tool name="ESET Mabezat Decryptor">
         <desktop companyName="(?i)^ESET" pattern="(?i)^esetmabezatadecryptor.*\.(exe|log)$" type="file"/>
         <download companyName="(?i)^ESET" pattern="(?i)^esetmabezatadecryptor.*\.(exe|log)$" type="file"/>

--- a/src/config/tools.xml
+++ b/src/config/tools.xml
@@ -666,6 +666,7 @@
     </tool>
     <tool name="Malwarebytes (log)">
         <desktop companyName="" pattern="(?i)^(mbam|Malwarebyte).*\.txt" type="file"/>
+        <desktopCommon companyName="" pattern="(?i)^mbst-grab-results\.zip$" type="file"/>
         <download companyName="" pattern="(?i)^(mbam|Malwarebyte).*\.txt" type="file"/>
     </tool>
     <tool name="MbrScan">

--- a/src/kp_includes/functions/remove.au3
+++ b/src/kp_includes/functions/remove.au3
@@ -259,7 +259,7 @@ Func RemoveFileHandler($sPathOfFile, Const ByRef $aElements)
 EndFunc   ;==>RemoveFileHandler
 
 Func RemoveAllFileFromWithMaxDepth($sPath, Const ByRef $aElements, $iDetpth = -2)
-	Local $aArray = _FileListToArrayRec($sPath, "*.exe;*.txt;*.lnk;*.log;*.reg;*.zip;*.dat;*.scr;*.com;*.bat;*.mbr;*.iso;*.pif", $FLTAR_FILESFOLDERS, $iDetpth, $FLTAR_NOSORT, $FLTAR_FULLPATH)
+	Local $aArray = _FileListToArrayRec($sPath, "*.exe;*.txt;*.lnk;*.log;*.reg;*.zip;*.dat;*.scr;*.com;*.bat;*.mbr;*.iso;*.pif;*.rtf", $FLTAR_FILESFOLDERS, $iDetpth, $FLTAR_NOSORT, $FLTAR_FULLPATH)
 
 	If @error <> 0 Then
 		Return Null


### PR DESCRIPTION
The Malwarebytes Support Tool itself is not removed, because it has uses outside of disinfection and the user might want to keep it around. The ESET SysInspector process is not killed, because there is a bundled SysInspector included in the ESET antivirus, with the same filename but in a different location.

I have not had time to work on the CLI parameters yet, but I'll try to work on that soon.