### PR TITLE
Version number related improvements

### DIFF
--- a/src/kp_includes/functions/utils.au3
+++ b/src/kp_includes/functions/utils.au3
@@ -244,7 +244,7 @@ EndFunc   ;==>FormatForUseRegistryKey
 
 Func GetOsVersion()
 	; https://www.autoitscript.com/forum/topic/183139-windows-10-complete-build-numberversion/
-	$sCommand = "Powershell [System.Environment]::OSVersion.Version.tostring()"
+	$sCommand = "cmd /c ver"
 	$iPID = run($sCommand , "" , @SW_HIDE , $stdout_child)
 
 	$sOutput = ""
@@ -254,5 +254,5 @@ Func GetOsVersion()
         If @error Then ExitLoop
     WEnd
 
-	Return stringsplit($sOutput , @CRLF, 2)[0]
+	Return stringsplit($sOutput , " ]", 2)[3]
 EndFunc

--- a/src/kp_includes/functions/utils.au3
+++ b/src/kp_includes/functions/utils.au3
@@ -216,6 +216,8 @@ Func GetHumanVersion()
 			Return "Windows 8.1"
 		Case "WIN_10"
 			Return "Windows 10"
+		Case "WIN_11"
+			Return "Windows 11"
 		Case Else
 			Return "Unsupported OS"
 	EndSwitch


### PR DESCRIPTION
This adds Windows 11 as a supported OS in the OS section of the text report, and adjusts the version number to include an accurate revision number (10.0.19044.2965 instead of 10.0.19044.0). I tested these changes on Windows 7, Windows 10 21H2, Windows 11 22H2, and the latest insider build.